### PR TITLE
野放しにされていたExceptionをしっかり投げられるように変更する

### DIFF
--- a/src/Infra/Discord/Repository/DiscordMessageRepositoryImpl.php
+++ b/src/Infra/Discord/Repository/DiscordMessageRepositoryImpl.php
@@ -20,6 +20,7 @@ class DiscordMessageRepositoryImpl implements DiscordMessageRepository
     public function createMessage(DiscordDraftMessage $discordDraftMessage): void
     {
         $channel = $this->discord->getChannel($discordDraftMessage->discordChannelId->toString());
-        $channel->sendMessage($discordDraftMessage->discordMessageContent->toString());
+        $channel->sendMessage($discordDraftMessage->discordMessageContent->toString())
+            ->done();
     }
 }

--- a/src/Infra/Discord/Repository/MessageEventRepositoryImpl.php
+++ b/src/Infra/Discord/Repository/MessageEventRepositoryImpl.php
@@ -43,10 +43,12 @@ class MessageEventRepositoryImpl implements MessageEventRepository
         $this->discord->on(
             Event::MESSAGE_REACTION_ADD,
             function (MessageReaction $reaction) use (&$onEmojiReactionEvent) {
-                $reaction->fetch()->then(function (MessageReaction $reaction) use (&$onEmojiReactionEvent) {
-                    $this->logger->info('Loaded message.');
-                    $onEmojiReactionEvent($this->processMessageReaction($reaction));
-                });
+                $reaction->fetch()
+                    ->then(function (MessageReaction $reaction) use (&$onEmojiReactionEvent) {
+                        $this->logger->info('Loaded message.');
+                        $onEmojiReactionEvent($this->processMessageReaction($reaction));
+                    })
+                    ->done();
             }
         );
     }


### PR DESCRIPTION
どうやら最後にdoneしないとcatchしてなかったExceptionは投げてくれないようだ。

参考: https://github.com/reactphp/promise/issues/53